### PR TITLE
GHSA-45x7-px36-x8w8 : fix CVE for Wolfi package rabbitmq-messaging-topology-operator

### DIFF
--- a/rabbitmq-messaging-topology-operator.yaml
+++ b/rabbitmq-messaging-topology-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-messaging-topology-operator
   version: 1.12.2
-  epoch: 0
+  epoch: 1
   description: Open source RabbitMQ cluster operator. Kubernetes operator to deploy and manage RabbitMQ clusters.
   copyright:
     - license: MPL-2.0
@@ -14,20 +14,24 @@ environment:
       - git
       - go
   environment:
-    CGO_ENABLED: 0
-    GO111MODULE: on
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: b7080b728467ea75473cf283f413632a1a54170b
       repository: https://github.com/rabbitmq/messaging-topology-operator
       tag: v${{package.version}}
-      expected-commit: b7080b728467ea75473cf283f413632a1a54170b
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
 
   - uses: go/build
     with:
-      packages: .
       output: manager
+      packages: .
       tags: timetzdata
 
   - uses: strip


### PR DESCRIPTION
GHSA-45x7-px36-x8w8 : fix CVE for Wolfi package rabbitmq-messaging-topology-operator