### PR TITLE
GHSA-8r3f-844c-mc37 : fix CVE for Wolfi package aws-efs-csi-driver

### DIFF
--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-efs-csi-driver
   version: 1.7.6
-  epoch: 1
+  epoch: 2
   description: CSI driver for Amazon EFS.
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: k8s.io/kubernetes@v1.26.11
+      deps: k8s.io/kubernetes@v1.26.11 google.golang.org/protobuf@v1.33.0
 
   - runs: |
       # Our global LDFLAGS conflict with a Makefile parameter


### PR DESCRIPTION
GHSA-8r3f-844c-mc37 : fix CVE for Wolfi package aws-efs-csi-driver

Advisory data: https://github.com/wolfi-dev/advisories/blob/main/aws-efs-csi-driver.advisories.yaml