### PR TITLE
GHSA-5jpm-x58v-624v : fix CVE for Wolfi package cloudwatch-exporter

### DIFF
--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudwatch-exporter
   version: 0.15.5 # Check if the version bump in the mvn command is still needed next time this package is updated
-  epoch: 1
+  epoch: 2
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
     - license: Apache-2.0

--- a/cloudwatch-exporter/pombump-deps.yaml
+++ b/cloudwatch-exporter/pombump-deps.yaml
@@ -1,5 +1,4 @@
 patches:
-  - groupId: io.netty
-    artifactId: netty-codec-http
-    version: 4.1.108.Final
-    scope: import
+    - groupId: io.netty
+      artifactId: netty-codec-http
+      version: 4.1.108.Final


### PR DESCRIPTION
GHSA-5jpm-x58v-624v : fix CVE for Wolfi package cloudwatch-exporter

Advisory data: https://github.com/wolfi-dev/advisories/blob/main/cloudwatch-exporter.advisories.yaml