### PR TITLE
test

### DIFF
--- a/cargobump.yaml
+++ b/cargobump.yaml
@@ -1,0 +1,33 @@
+package:
+  name: cargobump
+  version: 0.0.2
+  epoch: 0
+  description: Rust tool to declaratively bump dependencies using cargo
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hectorj2f/cargobump.git
+      tag: v${{package.version}}
+      expected-commit: a73f667bcda95c3561668824fd9005842497b989
+
+  - uses: go/build
+    with:
+      packages: .
+      output: cargobump
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/cargobump
+    strip-prefix: v
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        cargobump version

--- a/pipelines/rust/cargobump.yaml
+++ b/pipelines/rust/cargobump.yaml
@@ -1,0 +1,35 @@
+name: Bump rust deps to a certain version
+
+# Leave go off here, some packages pin to an older version. Let's just assume this gets injected elsewhere.
+needs:
+  packages:
+    - git
+    - cargobump
+
+inputs:
+  cargoroot:
+    description: The root of the cargo lock file
+    default: .
+  bump-file:
+    description: |
+      Patches file to use for updating the Cargo lock file
+    default: ./cargobump-deps.yaml
+  packages:
+    description: |
+      Packages to be used for updating the Cargo lock file via command line flag    
+
+pipeline:
+  - runs: |
+      set -x
+      cd "${{inputs.cargoroot}}"
+      
+      BUMP_FILE_FLAG=""
+      PACKAGES_FLAG=""
+
+      if [ -n "${{inputs.packages}}" ]; then
+        PACKAGES_FLAG="--packages ${{inputs.packages}}"
+      elif [ -f "${{inputs.bump-file}}" ]; then
+        BUMP_FILE_FLAG="--bump-file ${{inputs.bump-file}}"
+      fi
+
+      cargobump $PACKAGES_FLAG $BUMP_FILE_FLAG


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
