### PR TITLE
Adding CVE patch for package geckodriver

### DIFF
--- a/geckodriver.yaml
+++ b/geckodriver.yaml
@@ -1,7 +1,7 @@
 package:
   name: geckodriver
   version: 0.35.0
-  epoch: 0
+  epoch: 1
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MPL-2.0
@@ -17,6 +17,10 @@ pipeline:
       repository: https://github.com/mozilla/geckodriver
       tag: v${{package.version}}
       expected-commit: 53f2b320033668644eae58a8f3af5c94f0efc0f5
+
+  - uses: patch
+    with:
+      patches: GHSA-h97m-ww89-6jmq.patch
 
   - name: Configure and Build
     uses: cargo/build


### PR DESCRIPTION
Adding CVE patch for package geckodriver and CVE GHSA-h97m-ww89-6jmq