### PR TITLE
Adding CVE patch for package argocd-image-updater

### DIFF
--- a/argocd-image-updater.yaml
+++ b/argocd-image-updater.yaml
@@ -1,7 +1,7 @@
 package:
   name: argocd-image-updater
   version: 0.15.2
-  epoch: 0
+  epoch: 1
   description: Automatic container image update for Argo CD
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,10 @@ pipeline:
       repository: https://github.com/argoproj-labs/argocd-image-updater
       tag: v${{package.version}}
       expected-commit: abc00725c94c1f8657b53e688be2e4ee8a5e7e57
+
+  - uses: patch
+    with:
+      patches: GHSA-r9px-m959-cxf4.patch
 
   - uses: go/bump
     with:

--- a/argocd-image-updater/GHSA-r9px-m959-cxf4.patch
+++ b/argocd-image-updater/GHSA-r9px-m959-cxf4.patch
@@ -1,0 +1,11 @@
+--- a/go.mod
++++ b/go.mod
+@@ -14,7 +14,7 @@ require (
+ 	github.com/bmatcuk/doublestar/v4 v4.6.1
+ 	github.com/bradleyfalzon/ghinstallation/v2 v2.6.0
+ 	github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4
+-	github.com/go-git/go-git/v5 v5.11.0
++	github.com/go-git/go-git/v5 v5.13.0
+ 	github.com/google/uuid v1.6.0
+ 	github.com/opencontainers/go-digest v1.0.0
+ 	github.com/opencontainers/image-spec v1.1.0


### PR DESCRIPTION
Adding CVE patch for package argocd-image-updater and CVE GHSA-r9px-m959-cxf4