### PR TITLE
Adding CVE patch for package kube-fluentd-operator

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 17
+  epoch: 18
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -50,6 +50,10 @@ pipeline:
       repository: https://github.com/vmware/kube-fluentd-operator
       tag: v${{package.version}}
       expected-commit: 20e6130591ab07d1c73fcc892a4f9146c5a26b25
+
+  - uses: patch
+    with:
+      patches: GHSA-2rxp-v6pw-ch6m.patch
 
   - uses: go/bump
     with:

--- a/kube-fluentd-operator/GHSA-2rxp-v6pw-ch6m.patch
+++ b/kube-fluentd-operator/GHSA-2rxp-v6pw-ch6m.patch
@@ -1,0 +1,12 @@
+diff --git a/image/Gemfile b/image/Gemfile
+index 94cfa21..b3e5291 100644
+--- a/image/Gemfile
++++ b/image/Gemfile
+@@ -14,7 +14,7 @@ gem 'fluent-plugin-datadog', "0.14.2"
+ gem 'fluent-plugin-elasticsearch', "5.3.0"
+ gem 'fluent-plugin-opensearch', "1.1.0"
+-gem 'fluent-plugin-gelf-hs', "1.0.8"
++gem 'fluent-plugin-gelf-hs', "1.1.0"
+ gem 'fluent-plugin-grafana-loki', "1.2.20"
+ gem 'fluent-plugin-grok-parser', "2.6.2"
+ gem 'fluent-plugin-json-in-json-2', "1.0.2"


### PR DESCRIPTION
Adding CVE patch for package kube-fluentd-operator and CVE GHSA-2rxp-v6pw-ch6m